### PR TITLE
chore(fix): Update code of conduct title and link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
-# Community participation guidelines
+# Code of conduct
 
 This repository is governed by Mozilla's code of conduct and etiquette guidelines.
-For more details, please read the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+For more details, read [Mozilla's Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
 ## Reporting violations
 
-For more information on how to report violations of the Community Participation Guidelines, please read our [How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.
+For more information on how to report violations of the Community Participation Guidelines, read the [How to report](https://www.mozilla.org/about/governance/policies/participation/reporting/) page.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,11 +1,7 @@
 # Reviewing guide
 
-## Values and guidelines
-
-All reviewers must abide by the [Code of Conduct](CODE_OF_CONDUCT.md); they are also protected by the Code of Conduct.
-A reviewer should not tolerate poor behavior and is encouraged to [report any behavior](CODE_OF_CONDUCT.md#Reporting_violations) that violates the Code of Conduct.
-
-Everyone participating must follow our [Community Participation Guidelines](CODE_OF_CONDUCT.md#Community_Participation_Guidelines)
+All reviewers must abide by the [code of conduct](CODE_OF_CONDUCT.md); they are also protected by the code of conduct.
+A reviewer should not tolerate poor behavior and is encouraged to [report any behavior](CODE_OF_CONDUCT.md#Reporting_violations) that violates the code of conduct.
 
 ## Review process
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

1. CODE_OF_CONDUCT.md: The heading in the file is updated to reflect the name of the file. The file in turn links to Mozilla's community participation guidelines. The new heading helps to differentiate between the two.

3. REVIEWING.md: The references to the code of conduct and community participation guidelines were both pointing to the same file. This has been cleaned up with just one link.

### Motivation

To keep the verbiage consistent and to remove redundant content

### Additional details

None

### Related issues and pull requests

None
